### PR TITLE
🐞Fix stylesheet URL typo for light theme in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <link
     rel="stylesheet"
     media="(prefers-color-scheme: light)"
-    href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple=dark.css"
+    href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css"
   />
 
 </head>


### PR DESCRIPTION
Fixes a URL typo which caused the stylesheet to not load for light mode users. Typo was = instead of -.